### PR TITLE
Bump to 0.89.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,11 @@ on:
       - 'master'
   push:
     branches:
+      - 'feature*'
+      - 'feature/*'
       - 'feature_*'
+      - 'hotfix*'
+      - 'hotifx/*'
       - 'master'
   schedule:
     - cron: '0 18 * * *'
@@ -53,10 +57,10 @@ jobs:
       with:
         path: 'darkwizard242.hugo'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         path: 'darkwizard242.hugo'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 hugo_app: hugo_extended
-hugo_version: 0.88.1
+hugo_version: 0.89.1
 hugo_osarch: {{ ansible_system }}-64bit
 hugo_dl_url: https://github.com/gohugoio/hugo/releases/download/v{{ hugo_version }}/{{ hugo_app }}_{{ hugo_version }}_{{ hugo_osarch }}.tar.gz
 hugo_bin_path: /usr/local/bin
@@ -27,7 +27,7 @@ hugo_bin_path: /usr/local/bin
 Variable      | Value (default)                                                                                                                     | Description
 ------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------
 hugo_app      | hugo_extended                                                                                                                       | Defines the app to install i.e. **hugo_extended**
-hugo_version  | 0.88.1                                                                                                                              | Defined to dynamically fetch the desired version to install. Defaults to: **0.88.1**
+hugo_version  | 0.89.1                                                                                                                              | Defined to dynamically fetch the desired version to install. Defaults to: **0.89.1**
 hugo_osarch   | {{ ansible_system }}-64bit                                                                                                          | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **{{ ansible_system }}-64bit**
 hugo_dl_url   | <https://github.com/gohugoio/hugo/releases/download/v{{> hugo_version }}/{{ hugo_app }}_{{ hugo_version }}_{{ hugo_osarch }}.tar.gz | Defines URL to download the hugo binary from.
 hugo_bin_path | /usr/local/bin                                                                                                                      | Defined to dynamically set the appropriate path to store hugo binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ For customizing behavior of role (i.e. placing binary of **hugo** package in dif
 
 ## Author Information
 
-This role was created by [Ali Muhammad](https://www.linkedin.com/in/ali-muhammad-759791130/).
+This role was created by [Ali Muhammad](https://www.alimuhammad.dev/).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for hugo
 
 hugo_app: hugo_extended
-hugo_version: 0.88.1
+hugo_version: 0.89.1
 hugo_osarch: "{{ ansible_system }}-64bit"
 hugo_dl_url: https://github.com/gohugoio/hugo/releases/download/v{{ hugo_version }}/{{ hugo_app }}_{{ hugo_version }}_{{ hugo_osarch }}.tar.gz
 hugo_bin_path: /usr/local/bin

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=ansible-role-hugo
 sonar.organization=tech-overlord-github
 sonar.projectName=ansible-role-hugo
 sonar.coverage.exclusions=**/**
+sonar.python=3
 #sonar.projectVersion=$TRAVIS_JOB_ID
 
 # =====================================================


### PR DESCRIPTION
- Bump hugo version to **0.89.1**
- Define sonar.python in sonarcloud config
- Update push branches in `build-and-test` github action workflow + bump python to 3.10.0.
- Bump Python 3.10.0 in `release` github action workflow